### PR TITLE
Add .taskcluster.yml to test building, linting

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,0 +1,47 @@
+---
+version: 1
+policy:
+  pullRequests: public
+tasks:
+  $let:
+    $mergeDeep:
+      # Defaults
+      - should_run: false
+        clone_url:
+        sha:
+      - $switch:
+          'tasks_for == "github-pull-request"':
+            should_run: {$eval: 'event["action"] in ["opened", "reopened", "synchronize"]'}
+            clone_url: ${event.pull_request.head.repo.clone_url}
+            sha: ${event.pull_request.head.sha}
+          'tasks_for == "github-push"':
+            should_run: true
+            clone_url: ${event.repository.clone_url}
+            sha: ${event.after}
+  in:
+  - $if: should_run
+    then:
+      provisionerId: proj-taskcluster
+      workerType: ci
+      created: {$fromNow: ''}
+      deadline: {$fromNow: '1 day'}
+      expires: {$fromNow: '1 year 1 second'}  # 1 second so artifacts expire first, despite rounding errors
+      payload:
+        maxRunTime: 3600
+        image: "node:14"
+        command:
+          - /bin/bash
+          - '--login'
+          - '-c'
+          - >-
+            git clone ${clone_url} repo &&
+            cd repo &&
+            git config advice.detachedHead false &&
+            git checkout ${sha} &&
+            yarn &&
+            yarn lint
+      metadata:
+        name: "taskcluster-net test"
+        description: "A landing page at https://taskcluster.net, for those interested in Taskcluster"
+        owner: taskcluster-internal@mozilla.com
+        source: ${clone_url}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Note that this is not the "main" Taskcluster application; for that, see https://
 
 We welcome pull requests from everyone. We do expect everyone to adhere to the [Mozilla Community Participation Guidelines][participation].
 
-To get started developing this application, clone the respository and run
+To get started developing this application, clone the repository and run
 
 ```shell
 $ yarn


### PR DESCRIPTION
Add a `.taskcluster.yml`, based on https://github.com/taskcluster/taskcluster-lib-scopes/blob/main/.taskcluster.yml, that runs ``yarn && yarn lint``.

Part of issue #4. It may require additional work to enable the Community-TC Integration GitHub App, and to debug.

To test this locally, I used the json-e Python library:

```python
import jsone, yaml

context = {
  'event':  {
    'action': 'opened',
        'after': 'sha:after',
        'pull_request': {
            'head': {
               'repo': {
                   'clone_url': 'http://example.com/pull_request_url'
                },
                'sha': 'sha:head',
            },
         },
         'repository': {'clone_url': 'http://example.com/repository_clone_url'}},
     'tasks_for': 'github-pull-request'
}
template = yaml.load(open(".taskcluster.yml", "r"), Loader=yaml.FullLoader)
print(yaml.dump(jsone.render(template, context)))
```

which renders:

```yaml
policy:
  pullRequests: public
tasks:
- created: '2020-10-01T22:52:35.086Z'
  deadline: '2020-10-02T22:52:35.086Z'
  expires: '2021-10-01T22:52:36.086Z'
  metadata:
    description: A landing page at https://taskcluster.net, for those interested in
      Taskcluster
    name: taskcluster-net test
    owner: taskcluster-internal@mozilla.com
    source: http://example.com/pull_request_url
  payload:
    command:
    - /bin/bash
    - --login
    - -c
    - git clone http://example.com/pull_request_url repo && cd repo && git config
      advice.detachedHead false && git checkout sha:head && yarn && yarn lint
    image: node:14
    maxRunTime: 3600
  provisionerId: proj-taskcluster
  workerType: ci
version: 1
```

I can then replace context elements (such as ``context['tasks_for'] = 'github-push'``) to try out other paths.